### PR TITLE
Add project makefile and odk.bat file

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -102,14 +102,14 @@ Repo management:
 * clean:						Delete all temporary files
 
 Examples: 
-* sh run.sh make mappings
-* sh run.sh make update_repo
-* sh run.sh make test
+* sh odk.sh make mappings
+* sh odk.sh make update_repo
+* sh odk.sh make test
 
 Tricks:
 * Add -B to the end of your command to force re-running it even if nothing has changed
-* Use the IMAGE parameter to the run.sh script to use a different image like odklite
-* Use ODK_DEBUG=yes sh run.sh make ... to print information about timing and debuggingYUY
+* Use the IMAGE parameter to the odk.sh script to use a different image like odklite
+* Use ODK_DEBUG=yes sh odk.sh make ... to print information about timing and debugging
 
 endef
 export data

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -26,6 +26,8 @@ and then run the `dependencies` goal together with the mappings goal:
 IMAGE=odkfull:dev sh odk.sh make mappings
 ```
 
+*Note: If running on a Windows machine, replace `sh odk.sh` with `odk.bat` in the above commands.*
+
 ## Design decisions:
 
 1. Only mappings of base entities are extracted. This ensures that we do not import the same UBERON mapping for every species specific anatomy ontology (XAO). This is realised as a filtering step that relies on the crude assumption that the ontology ID is somehow reflected in the subject_id.

--- a/{{cookiecutter.project_name}}/odk.bat
+++ b/{{cookiecutter.project_name}}/odk.bat
@@ -1,0 +1,7 @@
+@echo off
+
+set ODK_JAVA_OPTS=-Xmx20G
+
+set "_path=%%cd%%"
+for %%a in ("%_path%") do set "p_dir=%%~dpa"
+docker run -v "%p_dir%\":/work -w /work -e 'ROBOT_JAVA_ARGS=%ODK_JAVA_OPTS%' -e 'JAVA_OPTS=%ODK_JAVA_OPTS%' --rm -ti obolibrary/odkfull %*

--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}.Makefile
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}.Makefile
@@ -1,0 +1,4 @@
+## Customize Makefile settings for {{cookiecutter.__project_slug}}
+## 
+## If you need to customize your Makefile, make
+## changes here rather than in the main Makefile


### PR DESCRIPTION
Added `{{cookiecutter.__project_slug}}.Makefile` since its existence is expected by the include statement in the Makefile. 

Added the `odk.bat` script for Windows users along with a note about using `odk.bat` in place of `sh odk.sh` in the README file.

Fixed a few copy/paste typos in the Makefile.